### PR TITLE
[ci skip] Get more Open Source Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 HPE StoreOnce PowerShell Module
 ===============================
 [![Flattr this git repo](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=vMarkus_K&url=https://github.com/mycloudrevolution/StoreOnce-PSModule&title=StoreOnce-PSModule&language=Powershell&tags=github&category=software)
+[![Help Contribute to Open Source](https://www.codetriage.com/mycloudrevolution/storeonce-psmodule/badges/users.svg)](https://www.codetriage.com/mycloudrevolution/storeonce-psmodule)
 
 # About
 
@@ -14,7 +15,7 @@ MY CLOUD-(R)EVOLUTION [mycloudrevolution.com](http://mycloudrevolution.com/)
 
 [StoreOnce PowerShell Module](http://mycloudrevolution.com/projekte/storeonce-powershell-module/)
 
-## Project Documentation: 
+## Project Documentation:
 
 [Read the Docs - StoreOnce PowerShell Module](http://storeonce-psmodule.readthedocs.io/en/latest/index.html)
 
@@ -143,11 +144,11 @@ Version 0.7
 + Enhanced: More details for Get-SOCatStores
 
 Version 0.6
-+ Enhanced: Parameter Position declaration 
++ Enhanced: Parameter Position declaration
 + Enhanced: Output Reorganization
 
 Version 0.5.2
-+ Enhanced: New Cert Handling 
++ Enhanced: New Cert Handling
 + Enhanced: Cmdlet Set-SOCredentials rewritten
 
 Version 0.5.1


### PR DESCRIPTION
[CodeTriage](https://www.codetriage.com/) is an app I have maintained
for the past 4-5 years with the goal of getting people involved in
Open Source projects like this one. The app sends subscribers a random
open issue for them to help "triage". For some languages you can also
suggested areas to add documentation.

The initial approach was inspired by seeing the work of the small
core team spending countless hours asking "what version was
this in" and "can you give us an example app". The idea is to
outsource these small interactions to a huge team of volunteers
and let the core team focus on their work.

I want to add a badge to the README of this project. The idea is to
provide an easy link for people to get started contributing to this
project. A badge indicates the number of people currently subscribed
to help the repo. The color is based off of open issues in the project.

Here are some examples of other projects that have a badge in their
README:

- https://github.com/crystal-lang/crystal
- https://github.com/rails/rails
- https://github.com/codetriage/codetriage

Thanks for building open source software, I would love to help you find some helpers.