### PR TITLE
Update Get-SOSIDs.psm1

### DIFF
--- a/PS-StoreOnce/Functions/Report/Get-SOSIDs.psm1
+++ b/PS-StoreOnce/Functions/Report/Get-SOSIDs.psm1
@@ -37,10 +37,10 @@ function Get-SOSIDs {
 				[Array] $Alias = $SIDsResponse.document.servicesets.serviceset.properties.alias
 				[Array] $OverallHealth = $SIDsResponse.document.servicesets.serviceset.properties.overallHealth
 				[Array] $SerialNumber = $SIDsResponse.document.servicesets.serviceset.properties.serialNumber
-				[Array] $CapacityBytes = $SIDsResponse.document.servicesets.serviceset.properties.capacityBytes
-				[Array] $FreeBytes = $SIDsResponse.document.servicesets.serviceset.properties.freeBytes
-				[Array] $UserBytes = $SIDsResponse.document.servicesets.serviceset.properties.userBytes
-				[Array] $DiskBytes = $SIDsResponse.document.servicesets.serviceset.properties.diskBytes
+				[Array] $CapacityBytes = $SIDsResponse.document.servicesets.serviceset.properties.localcapacityBytes
+				[Array] $FreeBytes = $SIDsResponse.document.servicesets.serviceset.properties.localfreeBytes
+				[Array] $UserBytes = $SIDsResponse.document.servicesets.serviceset.properties.localuserBytes
+				[Array] $DiskBytes = $SIDsResponse.document.servicesets.serviceset.properties.localdiskBytes
 				
 				for ($i = 0; $i -lt $SIDCount; $i++ ){		
 					$row = [PSCustomObject] @{


### PR DESCRIPTION
$SIDsResponse.document.servicesets.serviceset.properties


ssid                            : 1
name                            : Service Set 1
alias                           : SET1
serialNumber                    : CZ2
softwareVersion                 : 3.18.18-1945.1
productClass                    : HPE StoreOnce 4500 Backup
dedupeRatio                     : 7.3566144096294
healthLevel                     : 1
health                          : OK
status                          : Running
repHealthLevel                  : 1
repHealth                       : OK
repStatus                       : Running
overallHealthLevel              : 1
overallHealth                   : OK
overallStatus                   : Running
housekeepingHealthLevel         : 1
housekeepingHealth              : OK
housekeepingStatus              : Running
primaryNode                     : hpc
activeNode                      : hpc
cloudCapacityBytes              : 0
cloudDiskBytes                  : 0
cloudReadWriteLicensedDiskBytes : 0
cloudFreeBytes                  : 0
cloudUserBytes                  : 0
localCapacityBytes              : 49369890230600
localDiskBytes                  : 39652904514958
localFreeBytes                  : 6782065717576
localUserBytes                  : 291711128738397
combinedCapacityBytes           : 49369890230600
combinedDiskBytes               : 39652904514958
combinedFreeBytes               : 6782065717576
combinedUserBytes               : 291711128738397